### PR TITLE
115-fix-database-error-caused-by-logging-out

### DIFF
--- a/ekiree_dashboard/poetfolio/templates/base.html
+++ b/ekiree_dashboard/poetfolio/templates/base.html
@@ -51,9 +51,13 @@
                             <span class="material-icons">menu</span>
                     </button>
                     {% if user.is_authenticated %}
-                    <a type="button" id="logout" class="btn color-primary z-depth-0" href="{% url 'logout' %}?next={% firstof request.path '/' %}">
-                        <span class="material-icons">login</span>
-                    </a>
+                    <form method="post" action="{% url 'logout' %}" style="display: inline;">
+                        {% csrf_token %}
+                        <input type="hidden" name="next" value="{% firstof request.path '/' %}">
+                        <button type="submit" id="logout" class="btn color-primary z-depth-0">
+                            <span class="material-icons">login</span>
+                        </button>
+                    </form>
                     {% else %}
                     <a type="button" id="logout" class="btn color-primary z-depth-0" href="{% url 'login' %}?next={% firstof request.path '/' %}">
                         <span class="material-icons">login</span>
@@ -140,9 +144,13 @@
                         {# Log out #}
                         <li>
                             {% if user.is_authenticated %}
-                            <a type="button" class="btn menu-btn parent-btn z-depth-0" href="{% url 'logout' %}?next={% firstof request.path '/' %}">
-                                <span class="material-icons">login</span> logout
-                            </a>
+                            <form method="post" action="{% url 'logout' %}" style="display: inline;">
+                                {% csrf_token %}
+                                <input type="hidden" name="next" value="{% firstof request.path '/' %}">
+                                <button type="submit" class="btn menu-btn parent-btn z-depth-0">
+                                    <span class="material-icons">login</span> logout
+                                </button>
+                            </form>
                             {% else %}
                             <a type="button" class="btn menu-btn parent-btn z-depth-0" href="{% url 'login' %}?next={% firstof request.path '/' %}">
                                 <span class="material-icons">login</span> login


### PR DESCRIPTION
● Fix: Logout broken after Django 5.x upgrade

  After upgrading from Django 4.2 to Django 5.2, clicking the logout button no longer logs users out. This is due to a breaking change in Django 5.0: LogoutView no longer processes logout via GET requests.

  The existing logout links were <a> tags (GET requests). In Django 5.2, this triggers a code path that tries to render registration/logged_out.html without the context variables base.html expects, causing an error.

  Changes

  poetfolio/templates/base.html — Replaced both logout <a> tags with <form method="post"> elements containing a CSRF token, a hidden next field for redirect-after-logout, and a <button> styled identically to the original link. One in the top navbar,
  one in the sidebar.

  poetfolio/tests/test_views.py — Added LogoutTest with three tests:
  - GET to logout does not log the user out (documents Django 5.x behavior)
  - POST to logout logs out and redirects to /
  - Authenticated users see a POST form for logout in the template, not a GET link
