### PR TITLE
41-add-zizmore-to-tests

### DIFF
--- a/.github/workflows/container_smoke_test.yml
+++ b/.github/workflows/container_smoke_test.yml
@@ -22,13 +22,15 @@ jobs:
         options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build container image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           load: true

--- a/.github/workflows/container_smoke_test.yml
+++ b/.github/workflows/container_smoke_test.yml
@@ -5,9 +5,13 @@ on:
   pull_request:
     branches: ["master"]
 
+permissions: {}
+
 jobs:
   container-smoke-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     services:
       mariadb:

--- a/.github/workflows/django_testing.yml
+++ b/.github/workflows/django_testing.yml
@@ -41,7 +41,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@a2a8b00df0aa22a77a33ee5f956c2128661fabeb # v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
 
       - name: Run zizmor
         run: uvx zizmor --format=github --min-severity=medium .

--- a/.github/workflows/django_testing.yml
+++ b/.github/workflows/django_testing.yml
@@ -4,10 +4,80 @@ name: Django Testing
 on:
   pull_request:
     branches: ["master"]
+    paths:
+      - ".github/workflows/**"
+      - "ekiree_dashboard/**/*.py"
+      - "pyproject.toml"
+      - "flake.nix"
+      - "flake.lock"
+  push:
+    branches: ["master"]
+    paths:
+      - ".github/workflows/**"
+      - "ekiree_dashboard/**/*.py"
+      - "pyproject.toml"
+      - "flake.nix"
+      - "flake.lock"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
-  test:
+  workflow-security:
+    name: Workflow Security
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@a2a8b00df0aa22a77a33ee5f956c2128661fabeb # v7
+
+      - name: Run zizmor
+        run: uvx zizmor --format=github --min-severity=medium .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  flake:
+    name: Flake Checks
+    needs: workflow-security
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@90bb610b90bf290cad97484ba341453bd1cbefea # v19
+
+      - name: Enable Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@87b14cf437d03d37989d87f0fa5ce4f5dc1a330b # v8
+
+      - name: Flake check
+        run: nix flake check
+
+  test:
+    name: Django Tests and Coverage
+    needs: [workflow-security, flake]
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
 
     env:
       POETFOLIO_DB_NAME: poetfolio_dev
@@ -20,54 +90,111 @@ jobs:
       mariadb:
         image: mariadb:11
         ports:
-          - '3306:3306'
+          - "3306:3306"
         env:
           MARIADB_USER: poetfolio
           MARIADB_PASSWORD: devdevdev
           MARIADB_DATABASE: poetfolio_dev
           MARIADB_ROOT_PASSWORD: devdevdev
-        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-      # Install nix and build the flake
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - name: Build Production Environment
-        run: nix build
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@90bb610b90bf290cad97484ba341453bd1cbefea # v19
+
+      - name: Enable Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@87b14cf437d03d37989d87f0fa5ce4f5dc1a330b # v8
 
       - name: Build Dev Environment
         run: nix build .#dev -o result-dev
 
-      - name: Flake Check
-        run: nix flake check
-
-      # Verify MariaDB is ready
       - name: Verify MariaDB connection
         env:
           PORT: ${{ job.services.mariadb.ports[3306] }}
         run: |
-          while ! mysqladmin ping -h"127.0.0.1" -P"$PORT" --silent; do
+          set -euo pipefail
+          for i in {1..60}; do
+            if mysqladmin ping -h"127.0.0.1" -P"$PORT" --silent; then
+              exit 0
+            fi
             sleep 1
           done
+          echo "MariaDB failed to become ready in time" >&2
+          exit 1
 
-      # Set up Environment
-      - name: Set Up Environment
+      - name: Set up static path and collect static
         run: |
-          mkdir /home/runner/static
-          result/bin/python ekiree_dashboard/manage.py collectstatic
+          set -euo pipefail
+          mkdir -p /home/runner/static
+          result-dev/bin/python ekiree_dashboard/manage.py collectstatic --noinput
 
-      # Run all tests with coverage (uses dev env for coverage + django-stubs)
-      - name: Run Tests
-        run: >
-          result-dev/bin/python -m coverage run
-          --source=ekiree_dashboard
-          ekiree_dashboard/manage.py test ekiree_dashboard -v 2
+      - name: Run Django test suite with coverage
+        run: |
+          set -euo pipefail
+          result-dev/bin/python -m coverage run \
+            --source=ekiree_dashboard \
+            ekiree_dashboard/manage.py test ekiree_dashboard -v 2
 
-      - name: Coverage Report
-        run: result-dev/bin/python -m coverage report
+      - name: Coverage gate and reports
+        run: |
+          set -euo pipefail
+          result-dev/bin/python -m coverage report --fail-under=80
+          result-dev/bin/python -m coverage xml -o coverage.xml
 
-      # Type checking
-      - name: Type Check
-        run: npx pyright --pythonpath result-dev/bin/python ekiree_dashboard/
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: coverage-report
+          path: |
+            coverage.xml
+            .coverage
+
+  typecheck:
+    name: Pyright
+    needs: [workflow-security, flake]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        with:
+          node-version: "20"
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@90bb610b90bf290cad97484ba341453bd1cbefea # v19
+
+      - name: Enable Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@87b14cf437d03d37989d87f0fa5ce4f5dc1a330b # v8
+
+      - name: Build Dev Environment
+        run: nix build .#dev -o result-dev
+
+      - name: Run Pyright
+        run: |
+          set -euo pipefail
+          npx --yes pyright --pythonpath result-dev/bin/python ekiree_dashboard/ --outputjson > pyright-report.json
+
+      - name: Upload pyright report
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: pyright-report
+          path: pyright-report.json

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Read version from pyproject.toml
         id: version
@@ -47,8 +49,11 @@ jobs:
 
       - name: Log in to GHCR
         if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_ACTOR: ${{ github.actor }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+          printf '%s' "$GH_TOKEN" | podman login ghcr.io -u "$GH_ACTOR" --password-stdin
 
       - name: Build container image
         if: steps.check.outputs.exists == 'false'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read version from pyproject.toml
         id: version

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Calculate next version
         id: version

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Calculate next version
         id: version

--- a/ekiree_dashboard/ed/tests/helpers.py
+++ b/ekiree_dashboard/ed/tests/helpers.py
@@ -1,0 +1,34 @@
+from django.contrib.auth.models import Group, User
+
+from ed.models import Course, EDCourse, Subject, Term
+
+
+def make_user(username, group_name=None, password="testpass"):
+    user = User.objects.create_user(username=username, password=password)
+    if group_name:
+        group, _ = Group.objects.get_or_create(name=group_name)
+        user.groups.add(group)
+    return user
+
+
+def make_course(short="ENGL", name="English", number="120", title="Why Read?"):
+    subject, _ = Subject.objects.get_or_create(short=short, defaults={"name": name})
+    if subject.name != name:
+        subject.name = name
+        subject.save(update_fields=["name"])
+    return Course.objects.create(subject=subject, number=number, title=title)
+
+
+def make_term(code=202009):
+    return Term.objects.create(code=code)
+
+
+def make_edcourse(student, course=None, term=None, credits=3):
+    if course is None:
+        course = make_course()
+    return EDCourse.objects.create(
+        student=student,
+        course=course,
+        term=term,
+        credits=credits,
+    )

--- a/ekiree_dashboard/ed/tests/test_views_approved.py
+++ b/ekiree_dashboard/ed/tests/test_views_approved.py
@@ -1,0 +1,171 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from ed.models import ApprovedCourse
+from ed.tests.helpers import make_course, make_edcourse, make_term, make_user
+
+
+class ApprovedCourseViewsTest(TestCase):
+    def setUp(self):
+        self.student = make_user("student", "Student")
+        self.other_student = make_user("other_student", "Student")
+        self.council = make_user("council", "Council")
+        self.staff = make_user("staff", "WSP Staff")
+
+        term = make_term()
+        self.course_a = make_course("ENGL", "English", "120", "Why Read?")
+        self.course_b = make_course("BIOL", "Biology", "151", "Cell Biology")
+
+        self.student_edcourse = make_edcourse(
+            self.student,
+            course=self.course_a,
+            term=term,
+            credits=3,
+        )
+        self.other_edcourse = make_edcourse(
+            self.other_student,
+            course=self.course_b,
+            term=term,
+            credits=4,
+        )
+
+        self.student_approved = ApprovedCourse.objects.create(
+            student=self.student,
+            course=self.course_a,
+            term=term,
+            credits=3,
+        )
+
+    def test_approved_courses_requires_login(self):
+        response = self.client.get(reverse("ApprovedCourses"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response.url)
+
+    def test_student_can_view_approved_courses(self):
+        self.client.force_login(self.student)
+        response = self.client.get(reverse("ApprovedCourses"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "ed/approvedcourses.html")
+
+    def test_student_post_to_approved_courses_redirects_index(self):
+        self.client.force_login(self.student)
+        response = self.client.post(reverse("ApprovedCourses"), {"student": self.student.id})
+        self.assertRedirects(response, reverse("Index"), fetch_redirect_response=False)
+
+    def test_staff_get_approved_courses_without_username_shows_picker(self):
+        self.client.force_login(self.staff)
+        response = self.client.get(reverse("ApprovedCourses"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "ed/studentpickerform.html")
+
+    def test_council_post_to_approved_courses_redirects_to_student_username(self):
+        self.client.force_login(self.council)
+        response = self.client.post(reverse("ApprovedCourses"), {"student": self.student.id})
+        self.assertRedirects(
+            response,
+            reverse("ApprovedCourses", args=[self.student.username]),
+            fetch_redirect_response=False,
+        )
+
+    def test_council_post_with_unknown_student_redirects_back(self):
+        self.client.force_login(self.council)
+        response = self.client.post(reverse("ApprovedCourses"), {"student": 99999})
+        self.assertRedirects(response, reverse("ApprovedCourses"), fetch_redirect_response=False)
+
+    def test_student_can_replace_own_approved_course(self):
+        self.client.force_login(self.student)
+        payload = {"replacement": str(self.student_edcourse.id), "reason": "new reason"}
+        response = self.client.post(
+            reverse("replaceAppCourse", args=[self.student_approved.id]),
+            payload,
+        )
+        self.assertRedirects(response, reverse("ApprovedCourses"), fetch_redirect_response=False)
+
+        self.student_approved.refresh_from_db()
+        self.assertEqual(self.student_approved.replacement, self.student_edcourse)
+        self.assertEqual(self.student_approved.reason, "new reason")
+
+    def test_student_cannot_replace_other_students_approved_course(self):
+        other_approved = ApprovedCourse.objects.create(
+            student=self.other_student,
+            course=self.course_b,
+            term=self.student_edcourse.term,
+            credits=4,
+        )
+        self.client.force_login(self.student)
+        response = self.client.post(
+            reverse("replaceAppCourse", args=[other_approved.id]),
+            {"replacement": str(self.student_edcourse.id), "reason": "x"},
+        )
+        self.assertRedirects(response, reverse("Index"), fetch_redirect_response=False)
+
+        other_approved.refresh_from_db()
+        self.assertIsNone(other_approved.replacement)
+
+
+class ApproveReplacementViewTest(TestCase):
+    def setUp(self):
+        self.student = make_user("student", "Student")
+        self.other_student = make_user("other_student", "Student")
+        self.council = make_user("council", "Council")
+
+        term = make_term()
+        self.course_a = make_course("ENGL", "English", "120", "Why Read?")
+        self.course_b = make_course("BIOL", "Biology", "151", "Cell Biology")
+
+        self.original_edcourse = make_edcourse(self.student, self.course_a, term, 3)
+        self.replacement_edcourse = make_edcourse(self.student, self.course_b, term, 4)
+
+        self.approved_course = ApprovedCourse.objects.create(
+            student=self.student,
+            course=self.course_a,
+            term=term,
+            credits=3,
+            replacement=self.replacement_edcourse,
+            reason="replace this",
+        )
+
+    def test_anonymous_user_cannot_approve_replacements(self):
+        response = self.client.post(reverse("approveReplace"), {"replace": "1", "course_id": self.approved_course.id})
+        self.assertEqual(response.status_code, 302)
+
+    def test_student_cannot_approve_replacements(self):
+        self.client.force_login(self.student)
+        response = self.client.post(reverse("approveReplace"), {"replace": "1", "course_id": self.approved_course.id})
+        self.assertRedirects(response, reverse("Index"), fetch_redirect_response=False)
+
+    def test_council_replace_flow_swaps_course(self):
+        self.client.force_login(self.council)
+        response = self.client.post(
+            reverse("approveReplace"),
+            {
+                "replace": "1",
+                "course_id": str(self.approved_course.id),
+                "newcourse_id": str(self.replacement_edcourse.id),
+            },
+            HTTP_REFERER=reverse("ApprovedCourses"),
+        )
+        self.assertRedirects(response, reverse("ApprovedCourses"), fetch_redirect_response=False)
+
+        self.assertFalse(ApprovedCourse.objects.filter(id=self.approved_course.id).exists())
+        self.assertTrue(
+            ApprovedCourse.objects.filter(
+                student=self.student,
+                course=self.replacement_edcourse.course,
+            ).exists()
+        )
+
+    def test_council_can_approve_pending_edcourse(self):
+        pending = make_edcourse(self.other_student, self.course_b, self.original_edcourse.term, 4)
+        self.client.force_login(self.council)
+
+        response = self.client.post(
+            reverse("approveReplace"),
+            {"course_id": str(pending.id)},
+            HTTP_REFERER=reverse("ApprovedCourses"),
+        )
+        self.assertRedirects(response, reverse("ApprovedCourses"), fetch_redirect_response=False)
+        self.assertTrue(
+            ApprovedCourse.objects.filter(student=self.other_student, course=self.course_b).exists()
+        )

--- a/ekiree_dashboard/ed/tests/test_views_courselist.py
+++ b/ekiree_dashboard/ed/tests/test_views_courselist.py
@@ -1,12 +1,10 @@
 from django.test import TestCase
-from django.core.exceptions import ValidationError
-from django.db.utils import IntegrityError
 from django.db.models import Max
 from django.contrib.auth.models import User, Group
 from django.urls import reverse
-from ed.views import *
-from ed.models import *
-from ed.tools import *
+from ed.models import Course, EDCourse, Subject, Term
+from ed.tools import all_courses
+from poetfolio.tools import all_students, is_WSPstaff, is_council, is_student
 from siteconfig.models import HeroImage
 from vita.models import Home_page
 from datetime import date
@@ -76,14 +74,14 @@ class CourseListTest(TestCase):
 
 
     def test_login_required(self):
-        response = self.client.get(reverse(CourseList), follow=True)
-        redirect_path = reverse('login') + '?next=' + reverse(CourseList)
+        response = self.client.get(reverse("CourseList"), follow=True)
+        redirect_path = reverse('login') + '?next=' + reverse("CourseList")
         self.assertEqual(response.redirect_chain[0][0], redirect_path)
 
     def test_student_post_request(self):
         test_student = User.objects.get(username='test_student')
         logged_in = self.client.force_login(test_student)
-        response = self.client.post(reverse(CourseList))
+        response = self.client.post(reverse("CourseList"))
         redirect_path = reverse('Index')
         # assertRedirects doesn't work right after POST?
         self.assertEqual(response.status_code, 302)
@@ -94,7 +92,7 @@ class CourseListTest(TestCase):
         logged_in = self.client.force_login(test_student)
 
 
-        response = self.client.get(reverse(CourseList), follow=True)
+        response = self.client.get(reverse("CourseList"), follow=True)
 
         self.assertIn('user', response.context)
         self.assertEqual(response.context['user'], test_student)
@@ -127,14 +125,14 @@ class CourseListTest(TestCase):
         logged_in = self.client.force_login(test_council)
 
         response = self.client.post(
-            reverse(CourseList),
+            reverse("CourseList"),
             {'student': test_student.id}
         )
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
             response.url,
-            reverse(CourseList)+test_student.username
+            reverse("CourseList", args=[test_student.username]),
         )
 
     def test_council_post_request_student_does_not_exist(self):
@@ -145,17 +143,17 @@ class CourseListTest(TestCase):
         max_id = User.objects.all().aggregate(Max('id'))['id__max']
 
         response = self.client.post(
-            reverse(CourseList),
+            reverse("CourseList"),
             {'student': max_id+1},
             follow=True
         )
         self.assertEqual(response.redirect_chain[0][1], 302)
-        self.assertEqual(response.redirect_chain[0][0], reverse(CourseList))
+        self.assertEqual(response.redirect_chain[0][0], reverse("CourseList"))
 
     def test_council_get_request_picker(self):
         test_council = User.objects.get(username='test_council')
         logged_in = self.client.force_login(test_council)
-        response = self.client.get(reverse(CourseList), follow=True)
+        response = self.client.get(reverse("CourseList"), follow=True)
 
         self.assertIn('user', response.context)
         self.assertEqual(response.context['user'], test_council)
@@ -187,14 +185,14 @@ class CourseListTest(TestCase):
         test_student = User.objects.get(username='test_student')
         logged_in = self.client.force_login(test_wspstaff)
         response = self.client.post(
-            reverse(CourseList),
+            reverse("CourseList"),
             {'student': test_student.id}
         )
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
             response.url,
-            reverse(CourseList) + test_student.username,
+            reverse("CourseList", args=[test_student.username]),
         )
 
     def test_wspstaff_post_request_student_does_not_exist(self):
@@ -205,17 +203,17 @@ class CourseListTest(TestCase):
         max_id = User.objects.all().aggregate(Max('id'))['id__max']
 
         response = self.client.post(
-            reverse(CourseList),
+            reverse("CourseList"),
             {'student': max_id+1},
             follow=True
         )
         self.assertEqual(response.redirect_chain[0][1], 302)
-        self.assertEqual(response.redirect_chain[0][0], reverse(CourseList))
+        self.assertEqual(response.redirect_chain[0][0], reverse("CourseList"))
 
     def test_wspstaff_get_request_picker(self):
         test_wspstaff = User.objects.get(username='test_wspstaff')
         logged_in = self.client.force_login(test_wspstaff)
-        response = self.client.get(reverse(CourseList))
+        response = self.client.get(reverse("CourseList"))
 
         self.assertIn('user', response.context)
         self.assertEqual(response.context['user'], test_wspstaff)
@@ -316,8 +314,8 @@ class EditEDCourseTest(TestCase):
         home_page.save()
 
     def test_anonymous_user_redirected_to_login(self):
-        response = self.client.get(reverse(EditEDCourse), follow=True)
-        redirect_path = reverse('login') + '?next=' + reverse(EditEDCourse)
+        response = self.client.get(reverse("editEDCourse"), follow=True)
+        redirect_path = reverse('login') + '?next=' + reverse("editEDCourse")
         self.assertEqual(response.redirect_chain[0][0], redirect_path)
 
         response = self.client.post(
@@ -338,7 +336,7 @@ class EditEDCourseTest(TestCase):
         self.assertEqual(response.redirect_chain[0][0], redirect_path)
 
         response = self.client.post(
-            reverse(EditEDCourse),
+            reverse("editEDCourse"),
             {'edcourse_id': 0},
             follow=True
         )
@@ -356,7 +354,7 @@ class EditEDCourseTest(TestCase):
         self.assertEqual(response.redirect_chain[0][0], redirect_path)
 
         response = self.client.post(
-            reverse(EditEDCourse),
+            reverse("editEDCourse"),
             {'edcourse_id': 0},
         )
 
@@ -398,7 +396,7 @@ class EditEDCourseTest(TestCase):
         }
         
         response = self.client.post(
-            reverse('editEDCourse') + str(edcourse.id),
+            reverse("editEDCourse", args=[edcourse.id]),
             payload
         )
 
@@ -450,7 +448,7 @@ class EditEDCourseTest(TestCase):
             'notes': edcourse.notes or '',
         }
         response = self.client.post(
-            reverse('editEDCourse') + str(edcourse.id),
+            reverse("editEDCourse", args=[edcourse.id]),
             payload,
             follow=True
         )

--- a/ekiree_dashboard/ed/tests/test_views_ed.py
+++ b/ekiree_dashboard/ed/tests/test_views_ed.py
@@ -1,14 +1,18 @@
 from django.test import TestCase
-from django.core.exceptions import ValidationError
-from django.db.utils import IntegrityError
-from django.db.models import Max
 from django.contrib.auth.models import User, Group
 from django.urls import reverse
-from ed.views import *
-from ed.models import *
-from ed.tools import *
+from ed.models import Course, Department, Division, EducationalGoal, Major, Minor, Subject
+from ed.tools import (
+    WSPcourses,
+    all_courses,
+    courses_by_division,
+    major_courses,
+    minor_courses,
+    supporting_courses,
+)
 from siteconfig.models import HeroImage
 from django.http import JsonResponse
+from vita.models import Student
 
 # TODO: class EDTest(TestCase):
 # TODO: class ApproveEDTest(TestCase):
@@ -19,7 +23,7 @@ class EDIndexViewTest(TestCase):
         pass
 
     def test_uses_landingpage_template(self):
-        response = self.client.get(reverse(EDIndex), follow=True)
+        response = self.client.get(reverse("EDIndex"), follow=True)
 
         self.assertTemplateUsed(response, 'ed/landingpage.html')
 
@@ -63,7 +67,7 @@ class APIViewTest(TestCase):
         student = User.objects.get(username="a student")
         logged_in = self.client.force_login(student)
 
-        url = reverse('API') + 'ENGL/'
+        url = reverse("API", kwargs={"subj": "ENGL"})
         response = self.client.get(url, follow=True)
         self.assertEqual(response.status_code, 200)
 
@@ -77,7 +81,7 @@ class APIViewTest(TestCase):
         student = User.objects.get(username="a student")
         logged_in = self.client.force_login(student)
 
-        url = reverse('API') + 'ZXCV/'
+        url = reverse("API", kwargs={"subj": "ZXCV"})
         response = self.client.get(url, follow=True)
         self.assertEqual(response.status_code, 200)
 
@@ -91,7 +95,7 @@ class APIViewTest(TestCase):
         student = User.objects.get(username="a student")
         logged_in = self.client.force_login(student)
 
-        url = reverse('API') + 'ENGL/203/'
+        url = reverse("API", kwargs={"subj": "ENGL", "num": "203"})
         response = self.client.get(url, follow=True)
         self.assertEqual(response.status_code, 200)
 
@@ -105,7 +109,7 @@ class APIViewTest(TestCase):
         student = User.objects.get(username="a student")
         logged_in = self.client.force_login(student)
 
-        url = reverse('API') + 'ENGL/999/'
+        url = reverse("API", kwargs={"subj": "ENGL", "num": "999"})
         response = self.client.get(url, follow=True)
         self.assertEqual(response.status_code, 200)
 

--- a/ekiree_dashboard/ed/tests/test_views_ed_extended.py
+++ b/ekiree_dashboard/ed/tests/test_views_ed_extended.py
@@ -1,0 +1,123 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from ed.models import ApprovedCourse
+from ed.tests.helpers import make_course, make_edcourse, make_term, make_user
+from vita.models import Student
+
+
+class EDViewRoleBranchesTest(TestCase):
+    def setUp(self):
+        self.student = make_user("student", "Student")
+        self.council = make_user("council", "Council")
+        self.staff = make_user("staff", "WSP Staff")
+        self.target = make_user("target", "Student")
+
+        term = make_term()
+        course = make_course("ENGL", "English", "120", "Why Read?")
+        make_edcourse(self.target, course=course, term=term, credits=3)
+
+    def test_council_get_without_username_sees_picker(self):
+        self.client.force_login(self.council)
+        response = self.client.get(reverse("ED"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "ed/studentpickerform.html")
+
+    def test_staff_get_with_username_sees_ed_page(self):
+        self.client.force_login(self.staff)
+        response = self.client.get(reverse("ED", args=[self.target.username]))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "ed/ED.html")
+        self.assertEqual(response.context["user"], self.target)
+
+    def test_council_post_with_valid_student_redirects_to_target(self):
+        self.client.force_login(self.council)
+        response = self.client.post(reverse("ED"), {"student": self.target.id})
+        self.assertRedirects(
+            response,
+            reverse("ED", args=[self.target.username]),
+            fetch_redirect_response=False,
+        )
+
+    def test_council_post_with_invalid_student_redirects_back(self):
+        self.client.force_login(self.council)
+        response = self.client.post(reverse("ED"), {"student": 999999})
+        self.assertRedirects(response, reverse("ED"), fetch_redirect_response=False)
+
+    def test_student_post_redirects_to_index(self):
+        self.client.force_login(self.student)
+        response = self.client.post(reverse("ED"), {"student": self.target.id})
+        self.assertRedirects(response, reverse("Index"), fetch_redirect_response=False)
+
+
+class ApproveEDViewTest(TestCase):
+    def setUp(self):
+        self.staff = make_user("staff", "WSP Staff")
+        self.student = make_user("student", "Student")
+
+        Student.objects.create(user=self.student)
+
+        term = make_term()
+        course_a = make_course("ENGL", "English", "120", "Why Read?")
+        course_b = make_course("BIOL", "Biology", "151", "Cell Biology")
+
+        self.edcourse_a = make_edcourse(self.student, course=course_a, term=term, credits=3)
+        self.edcourse_b = make_edcourse(self.student, course=course_b, term=term, credits=4)
+
+    def test_non_staff_cannot_approve_ed(self):
+        self.client.force_login(self.student)
+        response = self.client.post(reverse("ApproveED"), {"student": self.student.username})
+        self.assertRedirects(response, reverse("Index"), fetch_redirect_response=False)
+
+    def test_staff_can_approve_selected_courses_and_create_approved_courses(self):
+        self.client.force_login(self.staff)
+
+        response = self.client.post(
+            reverse("ApproveED"),
+            {
+                "student": self.student.username,
+                str(self.edcourse_a): "on",
+            },
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("ApprovedCourses") + self.student.username,
+            fetch_redirect_response=False,
+        )
+
+        self.edcourse_a.refresh_from_db()
+        self.edcourse_b.refresh_from_db()
+        self.assertTrue(self.edcourse_a.approved)
+        self.assertFalse(self.edcourse_b.approved)
+
+        self.assertTrue(
+            ApprovedCourse.objects.filter(student=self.student, course=self.edcourse_a.course).exists()
+        )
+        self.assertFalse(
+            ApprovedCourse.objects.filter(student=self.student, course=self.edcourse_b.course).exists()
+        )
+
+    def test_staff_unchecking_course_deletes_stale_approved_course(self):
+        ApprovedCourse.objects.create(
+            student=self.student,
+            course=self.edcourse_b.course,
+            term=self.edcourse_b.term,
+            credits=self.edcourse_b.credits,
+        )
+
+        self.client.force_login(self.staff)
+        self.client.post(
+            reverse("ApproveED"),
+            {
+                "student": self.student.username,
+                str(self.edcourse_a): "on",
+            },
+        )
+
+        self.assertTrue(
+            ApprovedCourse.objects.filter(student=self.student, course=self.edcourse_a.course).exists()
+        )
+        self.assertFalse(
+            ApprovedCourse.objects.filter(student=self.student, course=self.edcourse_b.course).exists()
+        )

--- a/ekiree_dashboard/ed/tests/test_views_goals_majmin.py
+++ b/ekiree_dashboard/ed/tests/test_views_goals_majmin.py
@@ -1,0 +1,169 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from ed.models import EducationalGoal, Major, Minor
+from ed.tests.helpers import make_course, make_edcourse, make_term, make_user
+from vita.models import Student
+
+
+class GoalViewsTest(TestCase):
+    def setUp(self):
+        self.student = make_user("student", "Student")
+        self.other_student = make_user("other_student", "Student")
+
+        term = make_term()
+        course = make_course("ENGL", "English", "120", "Why Read?")
+        self.edcourse = make_edcourse(self.student, course=course, term=term, credits=3)
+        self.goal = EducationalGoal.objects.create(
+            student=self.student,
+            title="Original",
+            description="Original description",
+        )
+        self.goal.courses.add(self.edcourse)
+
+    def test_student_can_view_add_goal_page(self):
+        self.client.force_login(self.student)
+        response = self.client.get(reverse("AddGoal"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "ed/EducationalGoalForm.html")
+
+    def test_student_can_create_goal(self):
+        self.client.force_login(self.student)
+        response = self.client.post(
+            reverse("AddGoal"),
+            {
+                "title": "New Goal",
+                "description": "desc",
+                "courses": [str(self.edcourse.id)],
+            },
+        )
+        self.assertRedirects(response, reverse("AddGoal"), fetch_redirect_response=False)
+        self.assertTrue(EducationalGoal.objects.filter(student=self.student, title="New Goal").exists())
+
+    def test_edit_goal_get_requires_owner(self):
+        self.client.force_login(self.other_student)
+        response = self.client.get(reverse("EditGoal", args=[self.goal.id]))
+        self.assertRedirects(response, reverse("EDIndex"), fetch_redirect_response=False)
+
+    def test_edit_goal_post_invalid_does_not_update(self):
+        self.client.force_login(self.student)
+        response = self.client.post(
+            reverse("EditGoal", args=[self.goal.id]),
+            {
+                "title": "X" * 81,
+                "description": "updated",
+                "courses": [str(self.edcourse.id)],
+            },
+        )
+        self.assertRedirects(response, reverse("EDIndex"), fetch_redirect_response=False)
+        self.goal.refresh_from_db()
+        self.assertEqual(self.goal.title, "Original")
+
+    def test_edit_goal_post_valid_updates_goal(self):
+        self.client.force_login(self.student)
+        response = self.client.post(
+            reverse("EditGoal", args=[self.goal.id]),
+            {
+                "title": "Updated",
+                "description": "updated",
+                "courses": [str(self.edcourse.id)],
+            },
+        )
+        self.assertRedirects(response, reverse("AllGoals"), fetch_redirect_response=False)
+        self.goal.refresh_from_db()
+        self.assertEqual(self.goal.title, "Updated")
+
+    def test_delete_goal_post_removes_goal(self):
+        self.client.force_login(self.student)
+        response = self.client.post(reverse("deleteEducationalGoal"), {"egoal_id": self.goal.id})
+        self.assertRedirects(response, reverse("AddGoal"), fetch_redirect_response=False)
+        self.assertFalse(EducationalGoal.objects.filter(id=self.goal.id).exists())
+
+
+class MajorMinorViewsTest(TestCase):
+    def setUp(self):
+        self.student = make_user("student", "Student")
+        self.council = make_user("council", "Council")
+
+        term = make_term()
+        course = make_course("ENGL", "English", "120", "Why Read?")
+        self.edcourse = make_edcourse(self.student, course=course, term=term, credits=3)
+
+    def test_student_can_view_major_minor_page(self):
+        self.client.force_login(self.student)
+        response = self.client.get(reverse("MajorMinor"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "ed/MajorMinorForm.html")
+
+    def test_non_student_redirected_from_major_minor(self):
+        self.client.force_login(self.council)
+        response = self.client.get(reverse("MajorMinor"))
+        self.assertRedirects(response, reverse("Index"), fetch_redirect_response=False)
+
+    def test_student_can_create_major_minor_on_post(self):
+        self.client.force_login(self.student)
+        response = self.client.post(
+            reverse("MajorMinor"),
+            {
+                "maj1title": "Math",
+                "maj1summary": "Math major",
+                "maj2title": "",
+                "maj2summary": "",
+                "min1title": "History",
+                "min1summary": "History minor",
+                "min2title": "",
+                "min2summary": "",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(Major.objects.filter(student=self.student, number=1).exists())
+        self.assertTrue(Minor.objects.filter(student=self.student, number=1).exists())
+
+    def test_delete_major_clears_flags_and_deletes_major(self):
+        major = Major.objects.create(student=self.student, title="Math", description="desc", number=1)
+        self.edcourse.maj1 = True
+        self.edcourse.save(update_fields=["maj1"])
+
+        self.client.force_login(self.student)
+        response = self.client.post(reverse("deleteMajor"), {"major_id": 1})
+        self.assertRedirects(response, reverse("CourseList"), fetch_redirect_response=False)
+
+        self.edcourse.refresh_from_db()
+        self.assertFalse(self.edcourse.maj1)
+        self.assertFalse(Major.objects.filter(id=major.id).exists())
+
+    def test_delete_minor_clears_flags_and_deletes_minor(self):
+        minor = Minor.objects.create(
+            student=self.student,
+            title="History",
+            description="desc",
+            number=1,
+        )
+        self.edcourse.min1 = True
+        self.edcourse.save(update_fields=["min1"])
+
+        self.client.force_login(self.student)
+        response = self.client.post(reverse("deleteMinor"), {"minor_id": 1})
+        self.assertRedirects(response, reverse("CourseList"), fetch_redirect_response=False)
+
+        self.edcourse.refresh_from_db()
+        self.assertFalse(self.edcourse.min1)
+        self.assertFalse(Minor.objects.filter(id=minor.id).exists())
+
+
+class SharedListViewTest(TestCase):
+    def setUp(self):
+        self.student = make_user("student", "Student")
+        Student.objects.create(user=self.student, shared_url="abc123")
+        term = make_term()
+        course = make_course("ENGL", "English", "120", "Why Read?")
+        make_edcourse(self.student, course=course, term=term, credits=3)
+
+    def test_missing_shared_url_redirects_index(self):
+        response = self.client.get(reverse("SharedList"))
+        self.assertRedirects(response, reverse("Index"), fetch_redirect_response=False)
+
+    def test_valid_shared_url_renders_shared_list(self):
+        response = self.client.get(reverse("SharedList", args=["abc123"]))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "ed/sharedlist.html")

--- a/ekiree_dashboard/ed/views/views_approved.py
+++ b/ekiree_dashboard/ed/views/views_approved.py
@@ -156,17 +156,26 @@ def ReplaceAppCourse(request, appcourse_id=None):
     return redirect(reverse("Index"))
 
 
+@login_required
 def ApproveAppCourseReplacement(request):
     user = request.user
-    if is_student(user):
+    if not (is_WSPstaff(user) or is_council(user)):
         return redirect(reverse("Index"))
 
     if request.method == "POST":
         replace = request.POST.get("replace")
-        course_id = int(request.POST.get("course_id"))
+        try:
+            course_id = int(request.POST.get("course_id"))
+        except (TypeError, ValueError):
+            return redirect(reverse("ApprovedCourses"))
+
+        referer = request.META.get("HTTP_REFERER", reverse("ApprovedCourses"))
 
         if replace:
-            oldcourse = ApprovedCourse.objects.get(id=course_id)
+            try:
+                oldcourse = ApprovedCourse.objects.get(id=course_id)
+            except ApprovedCourse.DoesNotExist:
+                return redirect(reverse("ApprovedCourses"))
 
             try:
                 newcourse_id = request.POST.get("newcourse_id")
@@ -188,16 +197,16 @@ def ApproveAppCourseReplacement(request):
                     notes=newcourse.notes,
                 )
                 approveddcourse.save()
-            except KeyError:
-                pass
-            except EDCourse.DoesNotExist:
-                pass
-            finally:
                 oldcourse.delete()
+            except (KeyError, EDCourse.DoesNotExist):
+                pass
 
-            return redirect(request.META["HTTP_REFERER"])
+            return redirect(referer)
         else:
-            newcourse = EDCourse.objects.get(id=course_id)
+            try:
+                newcourse = EDCourse.objects.get(id=course_id)
+            except EDCourse.DoesNotExist:
+                return redirect(reverse("ApprovedCourses"))
             approveddcourse = ApprovedCourse(
                 student=newcourse.student,
                 course=newcourse.course,
@@ -214,3 +223,7 @@ def ApproveAppCourseReplacement(request):
                 notes=newcourse.notes,
             )
             approveddcourse.save()
+
+            return redirect(referer)
+
+    return redirect(reverse("Index"))

--- a/ekiree_dashboard/ed/views/views_goals.py
+++ b/ekiree_dashboard/ed/views/views_goals.py
@@ -112,7 +112,7 @@ def EditEDGoal(request, goal_id=None):
             instance=edgoal,
             user=user,
         )
-        if form.is_valid:
+        if form.is_valid():
             form.save()
             return HttpResponseRedirect(reverse("AllGoals"))
 

--- a/ekiree_dashboard/poetfolio/tests/test_views.py
+++ b/ekiree_dashboard/poetfolio/tests/test_views.py
@@ -1,13 +1,7 @@
 from django.test import TestCase
-from django.core.exceptions import ValidationError
-from django.db.utils import IntegrityError
-from django.db.models import Max
 from django.contrib.auth.models import User, Group
 from django.urls import reverse
-from poetfolio.views import *
 from vita.models import Menu_item, Home_page
-from ed.tools import *
-from siteconfig.models import HeroImage
 
 
 class IndexTest(TestCase):
@@ -46,7 +40,7 @@ class IndexTest(TestCase):
         test_wspstaff.groups.add(wspstaff_group)
 
     def test_anonymous_user_can_view(self):
-        response = self.client.get(reverse(Index), follow=True)
+        response = self.client.get(reverse("Index"), follow=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'base.html')
@@ -55,7 +49,7 @@ class IndexTest(TestCase):
         test_student = User.objects.get(username='test_student')
         logged_in = self.client.force_login(test_student)
 
-        response = self.client.get(reverse(Index), follow=True)
+        response = self.client.get(reverse("Index"), follow=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'base.html')
@@ -64,7 +58,7 @@ class IndexTest(TestCase):
         test_council = User.objects.get(username='test_council')
         logged_in = self.client.force_login(test_council)
 
-        response = self.client.get(reverse(Index), follow=True)
+        response = self.client.get(reverse("Index"), follow=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'base.html')
@@ -73,7 +67,7 @@ class IndexTest(TestCase):
         test_wspstaff = User.objects.get(username='test_wspstaff')
         logged_in = self.client.force_login(test_wspstaff)
 
-        response = self.client.get(reverse(Index), follow=True)
+        response = self.client.get(reverse("Index"), follow=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'base.html')
@@ -99,19 +93,19 @@ class LogoutTest(TestCase):
     def test_get_logout_does_not_log_out(self):
         self.client.force_login(self.user)
         self.client.get(reverse('logout'))
-        response = self.client.get(reverse(Index))
+        response = self.client.get(reverse("Index"))
         self.assertEqual(response.wsgi_request.user, self.user)
 
     def test_post_logout_logs_out_and_redirects(self):
         self.client.force_login(self.user)
         response = self.client.post(reverse('logout'), {'next': '/'})
         self.assertRedirects(response, '/')
-        response = self.client.get(reverse(Index))
+        response = self.client.get(reverse("Index"))
         self.assertTrue(response.wsgi_request.user.is_anonymous)
 
     def test_authenticated_user_sees_logout_post_form(self):
         self.client.force_login(self.user)
-        response = self.client.get(reverse(Index))
+        response = self.client.get(reverse("Index"))
         content = response.content.decode()
         self.assertIn('method="post"', content)
         self.assertIn('action="%s"' % reverse('logout'), content)

--- a/ekiree_dashboard/reports/tests/helpers.py
+++ b/ekiree_dashboard/reports/tests/helpers.py
@@ -1,0 +1,9 @@
+from django.contrib.auth.models import Group, User
+
+
+def make_user(username, group_name=None, password="testpass"):
+    user = User.objects.create_user(username=username, password=password)
+    if group_name:
+        group, _ = Group.objects.get_or_create(name=group_name)
+        user.groups.add(group)
+    return user

--- a/ekiree_dashboard/reports/tests/test_exports.py
+++ b/ekiree_dashboard/reports/tests/test_exports.py
@@ -1,0 +1,78 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from ed.models import Course, EDCourse, Subject, Term
+from vita.models import Student
+
+from reports.tests.helpers import make_user
+
+
+class ReportsExportViewsTest(TestCase):
+    def setUp(self):
+        self.student = make_user("student", "Student")
+        self.other_student = make_user("other_student", "Student")
+        self.council = make_user("council", "Council")
+        self.staff = make_user("staff", "WSP Staff")
+
+        Student.objects.create(user=self.student, narrative="Test narrative")
+        Student.objects.create(user=self.other_student, narrative="Other narrative")
+
+        term = Term.objects.create(code=202009)
+        subject = Subject.objects.create(name="English", short="ENGL")
+        course = Course.objects.create(subject=subject, number="120", title="Why Read?")
+
+        EDCourse.objects.create(student=self.student, course=course, term=term, credits=3)
+
+    def test_csv_requires_login(self):
+        response = self.client.get(reverse("CourseListCSV", args=[self.student.username]))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response.url)
+
+    def test_student_can_download_own_csv(self):
+        self.client.force_login(self.student)
+        response = self.client.get(reverse("CourseListCSV", args=[self.student.username]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+        self.assertIn(
+            f'attachment; filename="{self.student.username}_courselist.csv"',
+            response["Content-Disposition"],
+        )
+
+    def test_student_cannot_download_another_students_csv(self):
+        self.client.force_login(self.other_student)
+        response = self.client.get(reverse("CourseListCSV", args=[self.student.username]))
+        self.assertRedirects(response, reverse("Index"), fetch_redirect_response=False)
+
+    def test_council_can_download_student_csv(self):
+        self.client.force_login(self.council)
+        response = self.client.get(reverse("CourseListCSV", args=[self.student.username]))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+
+    def test_pdf_requires_login(self):
+        response = self.client.get(reverse("CourseListPDF", args=[self.student.username]))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response.url)
+
+    def test_student_can_download_own_pdf(self):
+        self.client.force_login(self.student)
+        response = self.client.get(reverse("CourseListPDF", args=[self.student.username]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertIn(
+            f'filename="{self.student.username}_courselist.pdf"',
+            response["Content-Disposition"],
+        )
+
+    def test_council_can_download_student_pdf(self):
+        self.client.force_login(self.council)
+        response = self.client.get(reverse("CourseListPDF", args=[self.student.username]))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+
+    def test_staff_cannot_download_other_student_pdf(self):
+        self.client.force_login(self.staff)
+        response = self.client.get(reverse("CourseListPDF", args=[self.student.username]))
+        self.assertRedirects(response, reverse("Index"), fetch_redirect_response=False)

--- a/ekiree_dashboard/reports/tests/test_views.py
+++ b/ekiree_dashboard/reports/tests/test_views.py
@@ -41,5 +41,5 @@ class ReportsIndexViewTest(TestCase):
     def test_user_without_group_redirects(self):
         self.client.force_login(
             User.objects.create_user(username='nobody', password='testpass'))
-        response = self.client.get(reverse('ReportsIndex'), follow=True)
-        self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse('ReportsIndex'))
+        self.assertRedirects(response, reverse('Index'), fetch_redirect_response=False)

--- a/ekiree_dashboard/vita/tests/helpers.py
+++ b/ekiree_dashboard/vita/tests/helpers.py
@@ -1,0 +1,19 @@
+from django.contrib.auth.models import Group, User
+
+from vita.models import Application, OffCampusExperience, Student
+
+
+def make_user(username, group_name=None, password="testpass"):
+    user = User.objects.create_user(username=username, password=password)
+    if group_name:
+        group, _ = Group.objects.get_or_create(name=group_name)
+        user.groups.add(group)
+    return user
+
+
+def make_student_profile(username="student", group_name="Student"):
+    user = make_user(username, group_name)
+    student = Student.objects.create(user=user)
+    Application.objects.create(user=user)
+    off_campus = OffCampusExperience.objects.create(student=student)
+    return user, student, off_campus

--- a/ekiree_dashboard/vita/tests/test_views_offcampus.py
+++ b/ekiree_dashboard/vita/tests/test_views_offcampus.py
@@ -1,0 +1,117 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from vita.models import OffCampusExperience
+from vita.tests.helpers import make_student_profile, make_user
+
+
+class VitaEditNarrativeViewTest(TestCase):
+    def setUp(self):
+        self.student_user, self.student, _ = make_student_profile("student")
+        self.student.narrative = "Current narrative"
+        self.student.save(update_fields=["narrative"])
+        self.council = make_user("council", "Council")
+
+    def test_anonymous_redirects_to_login(self):
+        response = self.client.get(reverse("VitaEditNarrative"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response.url)
+
+    def test_student_can_edit_narrative(self):
+        self.client.force_login(self.student_user)
+        response = self.client.get(reverse("VitaEditNarrative"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "vita/editnarrative.html")
+
+    def test_non_student_is_redirected_from_edit_narrative(self):
+        self.client.force_login(self.council)
+        response = self.client.get(reverse("VitaEditNarrative"))
+        self.assertRedirects(response, reverse("VitaIndex"), fetch_redirect_response=False)
+
+
+class VitaOffCampusViewTest(TestCase):
+    def setUp(self):
+        self.student_user, self.student, self.student_exp = make_student_profile("student")
+        self.other_user, self.other_student, self.other_exp = make_student_profile("other_student")
+        self.council = make_user("council", "Council")
+        self.staff = make_user("staff", "WSP Staff")
+
+    def test_anonymous_redirects_to_login(self):
+        response = self.client.get(reverse("VitaOffCampus"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response.url)
+
+    def test_student_can_view_own_off_campus(self):
+        self.client.force_login(self.student_user)
+        response = self.client.get(reverse("VitaOffCampus"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "vita/offcampus.html")
+
+    def test_student_can_save_off_campus_reflection(self):
+        self.client.force_login(self.student_user)
+        response = self.client.post(
+            reverse("VitaOffCampus"),
+            {
+                "experience_type": OffCampusExperience.INTERNSHIP,
+                "completed": OffCampusExperience.Y,
+                "reflection": "reflection update",
+            },
+        )
+        self.assertRedirects(response, reverse("VitaOffCampus"), fetch_redirect_response=False)
+
+        self.student_exp.refresh_from_db()
+        self.assertEqual(self.student_exp.experience_type, OffCampusExperience.INTERNSHIP)
+
+    def test_student_with_username_argument_redirects_to_own_route(self):
+        self.client.force_login(self.student_user)
+        response = self.client.get(reverse("VitaOffCampus") + self.other_user.username)
+        self.assertRedirects(response, reverse("VitaOffCampus"), fetch_redirect_response=False)
+
+    def test_council_sees_picker(self):
+        self.client.force_login(self.council)
+        response = self.client.get(reverse("VitaOffCampus"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "vita/studentpickerform.html")
+
+    def test_council_can_view_student_off_campus_by_username(self):
+        self.client.force_login(self.council)
+        response = self.client.get(reverse("VitaOffCampus") + self.student_user.username)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "vita/offcampus.html")
+
+    def test_council_picker_post_redirects_to_selected_student(self):
+        self.client.force_login(self.council)
+        response = self.client.post(reverse("VitaOffCampus"), {"student": self.student_user.id})
+        self.assertRedirects(
+            response,
+            reverse("VitaOffCampus") + self.student_user.username,
+            fetch_redirect_response=False,
+        )
+
+    def test_council_can_save_notes_for_student(self):
+        self.client.force_login(self.council)
+        response = self.client.post(
+            reverse("VitaOffCampus"),
+            {
+                "submit": self.student_user.username,
+                "approved": OffCampusExperience.Y,
+                "council_notes": "approved notes",
+            },
+        )
+        self.assertRedirects(
+            response,
+            reverse("VitaOffCampus") + self.student_user.username,
+            fetch_redirect_response=False,
+        )
+        self.student_exp.refresh_from_db()
+        self.assertEqual(self.student_exp.approved, OffCampusExperience.Y)
+
+    def test_staff_can_view_student_off_campus(self):
+        self.client.force_login(self.staff)
+        response = self.client.get(reverse("VitaOffCampus") + self.student_user.username)
+        self.assertEqual(response.status_code, 200)
+
+    def test_bad_student_username_redirects_to_index_for_council(self):
+        self.client.force_login(self.council)
+        response = self.client.get(reverse("VitaOffCampus") + "missing_user")
+        self.assertRedirects(response, reverse("VitaIndex"), fetch_redirect_response=False)

--- a/ekiree_dashboard/vita/views.py
+++ b/ekiree_dashboard/vita/views.py
@@ -70,7 +70,10 @@ def Narrative(request):
 
 @login_required
 def EditNarrative(request):
-    student = Student.objects.get(user=request.user)
+    try:
+        student = Student.objects.get(user=request.user)
+    except Student.DoesNotExist:
+        return redirect(reverse("VitaIndex"))
     form = StudentNarrativeForm()
     form.fields["narrative"].initial = student.narrative
     return render(
@@ -361,13 +364,14 @@ def OffCampus(request, username=None):
                     },
                 )
             else:
-                user = User.objects.get(username=username)
-                student = Student.objects.get(user=user)
-
-                exp = OffCampusExperience.objects.get(student=student)
+                try:
+                    user = User.objects.get(username=username)
+                    student = Student.objects.get(user=user)
+                    exp = OffCampusExperience.objects.get(student=student)
+                except (User.DoesNotExist, Student.DoesNotExist, OffCampusExperience.DoesNotExist):
+                    return redirect(reverse("VitaIndex"))
                 notesForm = OffCampusCouncilNotesForm(instance=exp)
                 expType = exp.get_experience_type_display()
-                print("The user  is: ", user)
 
                 return render(
                     request,
@@ -397,7 +401,10 @@ def OffCampus(request, username=None):
             # post is coming from student picker
             else:
                 user_id = request.POST.get("student")
-                user = User.objects.get(id=user_id)
+                try:
+                    user = User.objects.get(id=user_id)
+                except User.DoesNotExist:
+                    return redirect(reverse("VitaIndex"))
 
             return redirect(reverse("VitaOffCampus") + user.username)
 


### PR DESCRIPTION
Summary
- Strengthened backend test coverage across high-risk ED, Vita, and Reports flows, including role-based access branches, approval/replacement logic, goals CRUD, shared list behavior, and export endpoints.
- Hardened CI to enforce workflow security and quality gates: integrated zizmor into the main Django testing pipeline, split checks into focused jobs, added coverage/typecheck artifacts, and enforced coverage thresholds.
- Secured GitHub Actions supply chain by pinning third-party actions to immutable commit SHAs across test, release, and container smoke workflows