### PR TITLE
131-seperate-db-migration-from-container-deploy

### DIFF
--- a/.github/workflows/container_smoke_test.yml
+++ b/.github/workflows/container_smoke_test.yml
@@ -114,7 +114,7 @@ jobs:
             -e POETFOLIO_STATIC=/app/static \
             -e ALLOWED_HOSTS='*' \
             ekiree-dashboard:test \
-            /app/bin/python /app/entrypoint.prod.py --migrate-only
+            --migrate-only
 
       - name: Verify skip-migrate mode serves after migration check
         run: |
@@ -130,7 +130,7 @@ jobs:
             -e POETFOLIO_STATIC=/app/static \
             -e ALLOWED_HOSTS='*' \
             ekiree-dashboard:test \
-            /app/bin/python /app/entrypoint.prod.py --skip-migrate
+            --skip-migrate
 
           for i in $(seq 1 6); do
             STATUS=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 http://127.0.0.1:8002/) || true

--- a/.github/workflows/container_smoke_test.yml
+++ b/.github/workflows/container_smoke_test.yml
@@ -42,7 +42,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Start container
+      - name: Start container (default mode)
         run: |
           docker run -d --name dashboard \
             -p 8000:8000 \
@@ -100,6 +100,68 @@ jobs:
             echo "Static file not served (expected 200, got $STATUS)."
             exit 1
           fi
+
+      - name: Verify migrate-only mode exits successfully
+        run: |
+          docker run --rm --name dashboard-migrate-only \
+            --add-host=host.docker.internal:host-gateway \
+            -e DOCKER_SECRETS=False \
+            -e POETFOLIO_SECRET_KEY=ci-test-key-not-for-production \
+            -e POETFOLIO_DB_NAME=poetfolio_dev \
+            -e POETFOLIO_DB_USER=root \
+            -e POETFOLIO_DB_PASSWORD=devdevdev \
+            -e POETFOLIO_DB_HOST=host.docker.internal \
+            -e POETFOLIO_STATIC=/app/static \
+            -e ALLOWED_HOSTS='*' \
+            ekiree-dashboard:test \
+            /app/bin/python /app/entrypoint.prod.py --migrate-only
+
+      - name: Verify skip-migrate mode serves after migration check
+        run: |
+          docker run -d --name dashboard-skip \
+            -p 8002:8000 \
+            --add-host=host.docker.internal:host-gateway \
+            -e DOCKER_SECRETS=False \
+            -e POETFOLIO_SECRET_KEY=ci-test-key-not-for-production \
+            -e POETFOLIO_DB_NAME=poetfolio_dev \
+            -e POETFOLIO_DB_USER=root \
+            -e POETFOLIO_DB_PASSWORD=devdevdev \
+            -e POETFOLIO_DB_HOST=host.docker.internal \
+            -e POETFOLIO_STATIC=/app/static \
+            -e ALLOWED_HOSTS='*' \
+            ekiree-dashboard:test \
+            /app/bin/python /app/entrypoint.prod.py --skip-migrate
+
+          for i in $(seq 1 6); do
+            STATUS=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 http://127.0.0.1:8002/) || true
+            echo "Attempt $i/6 - skip-migrate HTTP status: $STATUS"
+            if [ "$STATUS" -ge 200 ] 2>/dev/null && [ "$STATUS" -lt 600 ] 2>/dev/null; then
+              echo "Skip-migrate mode is serving (HTTP $STATUS)."
+              break
+            fi
+            sleep 5
+          done
+
+          FINAL_STATUS=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 http://127.0.0.1:8002/) || true
+          if [ "$FINAL_STATUS" -lt 200 ] 2>/dev/null || [ "$FINAL_STATUS" -ge 600 ] 2>/dev/null; then
+            echo "Skip-migrate container did not become ready (HTTP $FINAL_STATUS)."
+            docker logs --tail 100 dashboard-skip
+            exit 1
+          fi
+
+          docker stop dashboard-skip
+          SKIP_EXIT_CODE=$(docker inspect dashboard-skip --format='{{.State.ExitCode}}')
+          echo "Skip-migrate container exit code: $SKIP_EXIT_CODE"
+          case "$SKIP_EXIT_CODE" in
+            0|137|143)
+              echo "Skip-migrate container exit code accepted."
+              ;;
+            *)
+              echo "Skip-migrate container exited with unexpected code $SKIP_EXIT_CODE."
+              docker logs --tail 50 dashboard-skip
+              exit 1
+              ;;
+          esac
 
       - name: Verify graceful shutdown
         run: |

--- a/ekiree_dashboard/entrypoint.prod.py
+++ b/ekiree_dashboard/entrypoint.prod.py
@@ -1,4 +1,5 @@
 #!/app/bin/python
+import argparse
 import os
 import subprocess
 import time
@@ -7,6 +8,9 @@ import MySQLdb
 
 PYTHON = "/app/bin/python"
 GUNICORN = "/app/bin/gunicorn"
+
+MIGRATION_CHECK_MAX_ATTEMPTS = int(os.environ.get("MIGRATION_CHECK_MAX_ATTEMPTS", "60"))
+MIGRATION_CHECK_INTERVAL_SECONDS = int(os.environ.get("MIGRATION_CHECK_INTERVAL_SECONDS", "5"))
 
 
 def wait_for_database():
@@ -46,11 +50,71 @@ def run_migrations():
     subprocess.run([PYTHON, "manage.py", "migrate", "--noinput"], check=True)
 
 
+def wait_for_migrations():
+    """Wait until migrations are fully applied."""
+    print("Waiting for migrations to be applied...")
+    for attempt in range(1, MIGRATION_CHECK_MAX_ATTEMPTS + 1):
+        result = subprocess.run(
+            [PYTHON, "manage.py", "migrate", "--check", "--noinput"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            print("Migrations are up to date")
+            return
+
+        if attempt == MIGRATION_CHECK_MAX_ATTEMPTS:
+            print("Final migration check failed")
+            print(f"Return code: {result.returncode}")
+            if result.stdout.strip():
+                print("migrate --check stdout:")
+                print(result.stdout.strip())
+            if result.stderr.strip():
+                print("migrate --check stderr:")
+                print(result.stderr.strip())
+
+        print(
+            "Migrations are not yet applied "
+            f"(attempt {attempt}/{MIGRATION_CHECK_MAX_ATTEMPTS}) - sleeping"
+        )
+        time.sleep(MIGRATION_CHECK_INTERVAL_SECONDS)
+
+    raise SystemExit(
+        "Migrations were not applied within the expected time window. "
+        "Refusing to start Gunicorn."
+    )
+
+
 def start_gunicorn():
     os.execv(GUNICORN, [GUNICORN, "--bind", "0.0.0.0:8000", "--workers", "3", "poetfolio.wsgi:application"])
 
 
+def parse_args():
+    parser = argparse.ArgumentParser(description="Dashboard production entrypoint")
+    parser.add_argument("--migrate-only", action="store_true", help="Run migrations and exit")
+    parser.add_argument("--skip-migrate", action="store_true", help="Skip migrations and only serve")
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
+    args = parse_args()
+
+    if args.migrate_only and args.skip_migrate:
+        raise SystemExit("Cannot use --migrate-only and --skip-migrate together")
+
     wait_for_database()
-    run_migrations()
+
+    if args.migrate_only:
+        print("Entrypoint mode: migrate-only")
+        run_migrations()
+        raise SystemExit(0)
+
+    if args.skip_migrate:
+        print("Entrypoint mode: skip-migrate")
+        wait_for_migrations()
+    else:
+        print("Entrypoint mode: default (migrate + serve)")
+        run_migrations()
+
     start_gunicorn()


### PR DESCRIPTION
  Summary

  - Decouple database migrations from container startup by adding --migrate-only and --skip-migrate flags to entrypoint.prod.py
  - Add a dedicated migrate service to the production Swarm stack that runs migrations once, separately from the app service
  - The app service (--skip-migrate) waits for migrations to be applied before starting Gunicorn, closing the race window where Swarm's start-first strategy could serve traffic against an unmigrated schema
  - Use a YAML anchor for the dashboard image tag so it only needs updating in one place per release
  - Add CI smoke tests for both new entrypoint modes

  Test plan

  - Existing smoke test (default mode: migrate + serve) passes unchanged
  - New --migrate-only smoke test: container applies migrations and exits 0
  - New --skip-migrate smoke test: container waits for migrations, starts Gunicorn, serves HTTP, shuts down cleanly
  - Dev environment (develop/docker-compose.yaml) is unchanged — uses default entrypoint behavior